### PR TITLE
Use persistent internet connection.

### DIFF
--- a/rack-async-http-falcon-graphql-lazy-resolve/Gemfile
+++ b/rack-async-http-falcon-graphql-lazy-resolve/Gemfile
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gem "rack"
 gem "falcon"
+gem "thread-local"
 gem "async-http"
 gem "graphql"

--- a/rack-async-http-falcon-graphql-lazy-resolve/Gemfile.lock
+++ b/rack-async-http-falcon-graphql-lazy-resolve/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    async (1.28.7)
+    async (1.29.0)
       console (~> 1.10)
       nio4r (~> 2.3)
       timers (~> 4.1)
@@ -19,12 +19,12 @@ GEM
       async-http (~> 0.53)
     async-io (1.30.2)
       async (~> 1.14)
-    async-pool (0.3.4)
+    async-pool (0.3.5)
       async (~> 1.25)
     build-environment (1.13.0)
-    console (1.10.1)
+    console (1.11.1)
       fiber-local
-    falcon (0.37.2)
+    falcon (0.37.3)
       async (~> 1.13)
       async-container (~> 0.16.0)
       async-http (~> 0.54.0)
@@ -37,17 +37,13 @@ GEM
       rack (>= 1.0)
       samovar (~> 2.1)
     fiber-local (1.0.0)
-    graphql (1.12.4)
-    graphql-batch (0.4.3)
-      graphql (>= 1.3, < 2)
-      promise.rb (~> 0.7.2)
-    localhost (1.1.6)
+    graphql (1.12.7)
+    localhost (1.1.7)
     mapping (1.1.1)
-    nio4r (2.5.5)
+    nio4r (2.5.7)
     process-metrics (0.2.1)
       console (~> 1.8)
       samovar (~> 2.1)
-    promise.rb (0.7.4)
     protocol-hpack (1.4.2)
     protocol-http (0.21.0)
     protocol-http1 (0.13.2)
@@ -59,7 +55,8 @@ GEM
     samovar (2.1.4)
       console (~> 1.0)
       mapping (~> 1.0)
-    timers (4.3.2)
+    thread-local (1.1.0)
+    timers (4.3.3)
 
 PLATFORMS
   ruby
@@ -68,11 +65,8 @@ DEPENDENCIES
   async-http
   falcon
   graphql
-  graphql-batch
   rack
-
-RUBY VERSION
-   ruby 2.7.2p137
+  thread-local
 
 BUNDLED WITH
-   2.1.4
+   2.2.5

--- a/rack-async-http-falcon-graphql-lazy-resolve/app.rb
+++ b/rack-async-http-falcon-graphql-lazy-resolve/app.rb
@@ -1,13 +1,17 @@
 require_relative "schema"
 
+require 'securerandom'
+
 class App
   def self.call(env)
-    puts "Request start"
+    logger = Console.logger.with(name: SecureRandom.uuid)
 
-    result = Schema.execute("query { one two three }")
+    Async(logger: logger) do
+      result = Console.logger.measure(self, "Schema.execute") do
+        Schema.execute("query { one two three }")
+      end
 
-    puts "Request finish"
-
-    [200, {}, [result.to_json]]
+      [200, {}, [result.to_json]]
+    end.wait
   end
 end


### PR DESCRIPTION
Use a thread local to store the internet client. This ensures connections
persist between requests. In addition, improve the logging so that these
improvements are more visible.

This relates to the discussion in #4.